### PR TITLE
removed argument -XX:+CMSIncrementalPacing

### DIFF
--- a/minecraft@.service
+++ b/minecraft@.service
@@ -16,7 +16,7 @@ ProtectKernelModules=true # Block module system calls, also /usr/lib/modules. It
 ProtectControlGroups=true # It is hence recommended to turn this on for most services.
 # Implies MountAPIVFS=yes
 
-ExecStart=/bin/sh -c '/usr/bin/screen -DmS mc-%i /usr/bin/java -server -Xms512M -Xmx2048M -XX:+UseG1GC -XX:+CMSIncrementalPacing -XX:+CMSClassUnloadingEnabled -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -jar $(ls -v | grep -i "FTBServer.*jar\|minecraft_server.*jar" | head -n 1) nogui'
+ExecStart=/bin/sh -c '/usr/bin/screen -DmS mc-%i /usr/bin/java -server -Xms512M -Xmx2048M -XX:+UseG1GC -XX:+CMSClassUnloadingEnabled -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -jar $(ls -v | grep -i "FTBServer.*jar\|minecraft_server.*jar" | head -n 1) nogui'
 
 ExecReload=/usr/bin/screen -p 0 -S mc-%i -X eval 'stuff "reload"\\015'
 


### PR DESCRIPTION
Debian 9 and Java 12 doesn't contain the argument "-XX:+CMSIncrementalPacing". It is working without it.