### PR TITLE
Requires extended regular expressions to find jar

### DIFF
--- a/minecraft@.service
+++ b/minecraft@.service
@@ -29,7 +29,7 @@ ProtectControlGroups=true
 # It is hence recommended to turn this on for most services.
 # Implies MountAPIVFS=yes
 
-ExecStart=/bin/sh -c '/usr/bin/screen -DmS mc-%i /usr/bin/java -server -Xms512M -Xmx2048M -XX:+UseG1GC -XX:+CMSClassUnloadingEnabled -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -jar $(ls -v | grep -i "FTBServer.*jar\|craftbukkit.*jar\|spigot.*jar\|paper*.*jar\|forge*.*jar|minecraft_server.*jar" | head -n 1) nogui'
+ExecStart=/bin/sh -c '/usr/bin/screen -DmS mc-%i /usr/bin/java -server -Xms512M -Xmx2048M -XX:+UseG1GC -XX:+CMSClassUnloadingEnabled -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -jar $(ls -v | grep -iE "FTBServer.*jar\|craftbukkit.*jar\|spigot.*jar\|paper*.*jar\|forge*.*jar|minecraft_server.*jar" | head -n 1) nogui'
 
 ExecReload=/usr/bin/screen -p 0 -S mc-%i -X eval 'stuff "reload"\\015'
 


### PR DESCRIPTION
Without this edit, the script cannot find the jar file called minecraft_server.20w18a.jar