### PR TITLE
Fix broken `ExecStart` command

### DIFF
--- a/minecraft@.service
+++ b/minecraft@.service
@@ -35,23 +35,25 @@ Environment="MCMINMEM=512M" "MCMAXMEM=1024M"
 EnvironmentFile=-/opt/minecraft/%i/server.conf
 
 ExecStart=/bin/sh -c \
-    '/usr/bin/screen -DmS mc-%i \
-      /usr/bin/java \
-        -server \
-        -Xms${MCMINMEM} \
-        -Xmx${MCMAXMEM} \
-        -XX:+UseG1GC \
-        -XX:+CMSClassUnloadingEnabled \
-        -XX:ParallelGCThreads=2 \
-        -XX:MinHeapFreeRatio=5 \
-        -XX:MaxHeapFreeRatio=10 \
-        -jar $(find -L . \
-            -maxdepth 1 \
-            -type f \
-            -iregex ".*/\\(FTBServer\\|craftbukkit\\|spigot\\|paper\\|forge\\|minecraft_server\\).*jar" \
-            -print \
-            -quit) \
-        nogui'
+    'find -L . \
+      -maxdepth 1 \
+      -type f \
+      -iregex ".*/\\(FTBServer\\|craftbukkit\\|spigot\\|paper\\|forge\\|minecraft_server\\).*jar" \
+      -print0 \
+      -quit \
+    | xargs -0 -I{} \
+      /usr/bin/screen -DmS mc-%i \
+        /usr/bin/java \
+          -server \
+          -Xms${MCMINMEM} \
+          -Xmx${MCMAXMEM} \
+          -XX:+UseG1GC \
+          -XX:+CMSClassUnloadingEnabled \
+          -XX:ParallelGCThreads=2 \
+          -XX:MinHeapFreeRatio=5 \
+          -XX:MaxHeapFreeRatio=10 \
+          -jar {} \
+          nogui'
 
 ExecReload=/usr/bin/screen -p 0 -S mc-%i -X eval 'stuff "reload"\\015'
 

--- a/minecraft@.service
+++ b/minecraft@.service
@@ -45,10 +45,12 @@ ExecStart=/bin/sh -c \
         -XX:ParallelGCThreads=2 \
         -XX:MinHeapFreeRatio=5 \
         -XX:MaxHeapFreeRatio=10 \
-        -jar $(ls -v | \
-          grep -i \
-            "FTBServer.*jar\\|craftbukkit.*jar\\|spigot.*jar\\|paper*.*jar\\|forge*.*jar\\|minecraft_server.*jar" \
-          | head -n 1) \
+        -jar $(find -L . \
+            -maxdepth 1 \
+            -type f \
+            -iregex ".*/\\(FTBServer.*jar\\|craftbukkit.*jar\\|spigot.*jar\\|paper*.*jar\\|forge*.*jar\\|minecraft_server.*jar\\)" \
+            -print \
+            -quit) \
         nogui'
 
 ExecReload=/usr/bin/screen -p 0 -S mc-%i -X eval 'stuff "reload"\\015'

--- a/minecraft@.service
+++ b/minecraft@.service
@@ -34,7 +34,7 @@ Environment="MCMINMEM=512M" "MCMAXMEM=1024M"
 # Change memory values in environment file
 EnvironmentFile=-/opt/minecraft/%i/server.conf
 
-ExecStart=/bin/sh -c '/usr/bin/screen -DmS mc-%i /usr/bin/java -server -Xms${MCMINMEM} -Xmx${MCMAXMEM} -XX:+UseG1GC -XX:+CMSClassUnloadingEnabled -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -jar $(ls -v | grep -iE "FTBServer.*jar\|craftbukkit.*jar\|spigot.*jar\|paper.*jar\|forge.*jar\|minecraft_server.*jar" | head -n 1) nogui'
+ExecStart=/bin/sh -c '/usr/bin/screen -DmS mc-%i /usr/bin/java -server -Xms${MCMINMEM} -Xmx${MCMAXMEM} -XX:+UseG1GC -XX:+CMSClassUnloadingEnabled -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -jar $(ls -v | grep -i "FTBServer.*jar\\|craftbukkit.*jar\\|spigot.*jar\\|paper*.*jar\\|forge*.*jar\\|minecraft_server.*jar" | head -n 1) nogui'
 
 ExecReload=/usr/bin/screen -p 0 -S mc-%i -X eval 'stuff "reload"\\015'
 

--- a/minecraft@.service
+++ b/minecraft@.service
@@ -48,7 +48,7 @@ ExecStart=/bin/sh -c \
         -jar $(find -L . \
             -maxdepth 1 \
             -type f \
-            -iregex ".*/\\(FTBServer.*jar\\|craftbukkit.*jar\\|spigot.*jar\\|paper*.*jar\\|forge*.*jar\\|minecraft_server.*jar\\)" \
+            -iregex ".*/\\(FTBServer\\|craftbukkit\\|spigot\\|paper\\|forge\\|minecraft_server\\).*jar" \
             -print \
             -quit) \
         nogui'

--- a/minecraft@.service
+++ b/minecraft@.service
@@ -34,7 +34,22 @@ Environment="MCMINMEM=512M" "MCMAXMEM=1024M"
 # Change memory values in environment file
 EnvironmentFile=-/opt/minecraft/%i/server.conf
 
-ExecStart=/bin/sh -c '/usr/bin/screen -DmS mc-%i /usr/bin/java -server -Xms${MCMINMEM} -Xmx${MCMAXMEM} -XX:+UseG1GC -XX:+CMSClassUnloadingEnabled -XX:ParallelGCThreads=2 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -jar $(ls -v | grep -i "FTBServer.*jar\\|craftbukkit.*jar\\|spigot.*jar\\|paper*.*jar\\|forge*.*jar\\|minecraft_server.*jar" | head -n 1) nogui'
+ExecStart=/bin/sh -c \
+    '/usr/bin/screen -DmS mc-%i \
+      /usr/bin/java \
+        -server \
+        -Xms${MCMINMEM} \
+        -Xmx${MCMAXMEM} \
+        -XX:+UseG1GC \
+        -XX:+CMSClassUnloadingEnabled \
+        -XX:ParallelGCThreads=2 \
+        -XX:MinHeapFreeRatio=5 \
+        -XX:MaxHeapFreeRatio=10 \
+        -jar $(ls -v | \
+          grep -i \
+            "FTBServer.*jar\\|craftbukkit.*jar\\|spigot.*jar\\|paper*.*jar\\|forge*.*jar\\|minecraft_server.*jar" \
+          | head -n 1) \
+        nogui'
 
 ExecReload=/usr/bin/screen -p 0 -S mc-%i -X eval 'stuff "reload"\\015'
 


### PR DESCRIPTION
597ddff (#13) breaks the `ExecStart` command.

This PR was created to fix a bug that no longer exists.  The solution of using extended regular expressions was in fact incorrect, but just happened to cancel out the bug in certain cases.  Now that the bug has been fixed (dabf132), this breaks the regex in all cases.

Fixes #16