### PR TITLE
Remove mention of German control key

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ systemctl stop minecraft@FTBBeyond
 ```
 ### Enter Server Commands
 To enter the console "screen" is used (that's why it is in the script).
-**Note**: To detach (exit) screen press [STRG] + [A] followed by [D].
+**Note**: To detach (exit) screen press [CTRL] + [A] followed by [D].
 ```
 su - minecraft -c "/usr/bin/screen -r" minecraft
 ```


### PR DESCRIPTION
The STRG key can only be found on German keyboards. Using `CTRL` in the documentation is easier to understand IMHO. 