### PR TITLE
Remove -XX:+CMSClassUnloadingEnabled

### DIFF
--- a/minecraft@.service
+++ b/minecraft@.service
@@ -51,7 +51,6 @@ ExecStart=/bin/sh -c \
           -Xms${MCMINMEM} \
           -Xmx${MCMAXMEM} \
           -XX:+UseG1GC \
-          -XX:+CMSClassUnloadingEnabled \
           -XX:ParallelGCThreads=2 \
           -XX:MinHeapFreeRatio=5 \
           -XX:MaxHeapFreeRatio=10 \


### PR DESCRIPTION
The flag `-XX:+CMSClassUnloadingEnabled` is not supported under Java 16, and Java 16 or greater is required to run the latest minecraft_server.jar.

See [the issue](https://github.com/agowa338/MinecraftSystemdUnit/issues/30).